### PR TITLE
Update PlantItem.js

### DIFF
--- a/src/components/PlantItem.js
+++ b/src/components/PlantItem.js
@@ -1,9 +1,9 @@
 import CareScale from './CareScale'
 import '../styles/PlantItem.css'
 
-function PlantItem({ id, cover, name, water, light }) {
+function PlantItem({ cover, name, water, light }) {
 	return (
-		<li key={id} className='lmj-plant-item'>
+		<li className='lmj-plant-item'>
 			<img className='lmj-plant-item-cover' src={cover} alt={`${name} cover`} />
 			{name}
 			<div>


### PR DESCRIPTION
Dans le composant PlantItem, vous ne devez pas définir la clé (key) explicitement. La clé (key) doit être définie au niveau du composant parent (dans ce cas, le composant ShoppingList) lors de la création des éléments de liste, ce qui est déjà fait correctement dans votre code. Il n'est pas nécessaire ni recommandé de définir une clé (key) dans le composant PlantItem lui-même.